### PR TITLE
Make ansible-python play nice with version-pinning

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -29,7 +29,7 @@
 - name: "Install Packages | pip | {{ python_packages }}"
   pip:
     executable: "{{ python_pip_executable }}"
-    state: "{% if item is 'ansible' %}present{% else %}latest{% endif %}
+    state: "{% if item is 'ansible' %}present{% else %}latest{% endif %}"
     name: "{{ item }}"
   with_items: python_packages
   when: python_packages

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -29,7 +29,7 @@
 - name: "Install Packages | pip | {{ python_packages }}"
   pip:
     executable: "{{ python_pip_executable }}"
-    state: latest
+    state: "{% if item is 'ansible' %}present{% else %}latest{% endif %}
     name: "{{ item }}"
   with_items: python_packages
   when: python_packages


### PR DESCRIPTION
If Ansible is already installed, this will not upgrade it. Otherwise, it will still install the latest version.

Any forged systems will have ansible installed already.