### PR TITLE
Added travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+---
+language: python
+python: "2.7"
+
+env:
+  - SITE=test.yml
+
+before_install:
+  - sudo apt-get update -qq
+
+install:
+  # Install Ansible
+  - pip install ansible
+
+  # Add ansible.cfg to pick up roles path.
+  - "{ echo '[defaults]'; echo 'roles_path = ../'; } >> ansible.cfg"
+
+script:
+  # Check the role/playbook's syntax.
+  - "ansible-playbook -i tests/inventory tests/$SITE --syntax-check"
+
+  # Run the role/playbook with ansible-playbook.
+  - "ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo"
+
+  # Run the role/playbook in --check mode.
+  - "ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo --check"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [Python](https://www.python.org/) - Python is a programming language that lets you work quickly and integrate systems more effectively.
 
+[![Build Status](https://travis-ci.org/telusdigital/ansible-python.svg?branch=master)](https://travis-ci.org/telusdigital/ansible-python)
 [![Platforms](http://img.shields.io/badge/platforms-ubuntu-lightgrey.svg?style=flat)](#)
 
 Description

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,6 +4,8 @@
   roles:
     - role: ansible-python
   vars:
+    python_packages:
+     - ansible
     system_role: travis
     project: travis
     environment_tier: travis

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,10 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - role: ansible-python
+  vars:
+    system_role: travis
+    project: travis
+    environment_tier: travis
+    domain: travis


### PR DESCRIPTION
I added an extra test for installing 'ansible' in `python_packages` since we're having issues with this right now. The build is failing on the install python packages task.

```
TASK [ansible-python : Install Packages | pip | [u'ansible']] ******************
fatal: [localhost]: FAILED! => {"failed": true, "msg": "ERROR! template error while templating string: expected token 'name', got 'string'"}
```