### PR TITLE
Ansible v2 bugged on self-update prevention. 

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -30,7 +30,7 @@
 - name: "Install Packages | pip | {{ python_packages }}"
   pip:
     executable: "{{ python_pip_executable }}"
-    state: "{% if item is ['ansible'] %}present{% else %}latest{% endif %}"
+    state: latest
     name: "{{ item }}"
   with_items: python_packages
   when: python_packages


### PR DESCRIPTION
This bug is fixed in v2, so this workaround is no longer required.